### PR TITLE
Revert "Update newrelic to version 1.27.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "joi": "8.0.5",
     "lodash": "4.11.1",
     "md5": "2.1.0",
-    "newrelic": "1.27.0",
+    "newrelic": "1.26.2",
     "path": "0.12.7",
     "query-string": "4.1.0",
     "scarecrow": "3.0.0",


### PR DESCRIPTION
Reverts travi/travi-api#174 because the new version was unpublished